### PR TITLE
Added node.send for when no files are found that match the pattern.

### DIFF
--- a/fs/fs-file-lister.js
+++ b/fs/fs-file-lister.js
@@ -139,8 +139,11 @@ module.exports = function(RED) {
 					if ( arrayOut.length > 0 ) {
 						node.status({fill:'blue',shape:'dot',text:'# files ' + arrayOut.length})
 						msg.payload = arrayOut
-						node.send(msg)
+					} else {
+						node.status({fill:'red',shape:'dot',text:'No files found.'})
+                                                msg.payload = []
 					}
+					node.send(msg)
 				})
 
 			/*


### PR DESCRIPTION
This node will hang if there are no files that match the pattern. This returns an empty payload array to indicate no files found. This guarantees the node will move on to the next one.