### PR TITLE
Updated fs-lister to allow folder patterns, choose to look at files, folders or both and updated the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ To install a development version, use:
    - Remove spurious `console.log(file)`
    - Remove input `_msgid` from output so that all output messages get their own _msgid (Fixes [Issue #11](https://github.com/TotallyInformation/node-red-contrib-fs/issues/11))
    - Update dependencies to latest
-- 1.1.2 - new functionality
+- 1.1.2 - new functionality(\*)
    - Folder pattern matching added
    - Search for files, folders or both added
-   - all options now set able the incoming msg 
+   - all options now set able the incoming msg
+   - (\*) because of the new functionality, existing nodes may see more results returned
 # Depends On
 - [readdirp](https://github.com/paulmillr/readdirp)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 [Node-Red](http://nodered.org) nodes that work with the host filing system.
 
 # Nodes
-- [file-lister](docs/file-lister.html) - List all files in a given starting folder optionally with a filename filter pattern. Also has options for file details and sub-folder recursion.
+- [file-lister](docs/file-lister.html) - List all files and/or folders from a given starting folder based on the search
+option chosen. File and folder names allow filtering patterns. Also has options for file details and sub-folder recursion.
 - file-copier - In progress. Simple node to copy files (optionally with wildcard specifications).
 
 # Install
@@ -35,7 +36,10 @@ To install a development version, use:
    - Remove spurious `console.log(file)`
    - Remove input `_msgid` from output so that all output messages get their own _msgid (Fixes [Issue #11](https://github.com/TotallyInformation/node-red-contrib-fs/issues/11))
    - Update dependencies to latest
-
+- 1.1.2 - new functionality
+   - Folder pattern matching added
+   - Search for files, folders or both added
+   - all options now set able the incoming msg 
 # Depends On
 - [readdirp](https://github.com/paulmillr/readdirp)
 

--- a/docs/file-lister.html
+++ b/docs/file-lister.html
@@ -3,16 +3,10 @@
 	<h2>
 		Filing System Utilities: File Lister
 	</h2>
-	<h3>To Do</h3>
-	<ul>
-		<li>
-			Allow other overrides to be passed in.
-		</li>
-	</ul>
 	<h3>What does this node do?</h3>
 	<p>
 		This node searches a folder (and optionally sub-folders) for files. optionally
-		may filter on a specific file pattern.
+		may filter on a specific file and/or folder pattern.
 	</p>
 	<p>
 		The folder and files come from the computer and operating system that is
@@ -54,29 +48,43 @@
 			Max length is 1024
 		</li>
 		<li>
-			<b>Search sub-folders</b> Checkbox. If selected, sub-folders under the
-			start folder will also be searched.
+			<b>Folder Pattern</b> [folders] String that will be matched against folder names.
+			Standard "glob" file patterns are allowed. Defaults to '*' which will match all 
+			folders. Use the '!' to negate a folder - i.e. '!bin' means don't search the 'bin' 
+			folder. Multiple patterns can be used so "*,!bin,!data" means 'search all subfolders 
+			except 'bin' and 'data'. Max length is 1024
 		</li>
 		<li>
-			<b>Sub-folder Depth</b> Integer. Default 0 only searches the start folder.
-			Limits the depth of sub-folders that will be searched.
+			<b>Files/Folder/b> [lstype] Drop down that allows you to choice to return just files,
+			'folders or both
+		</li>
+		<li>
+			<b>Include hidden file/folders in output</b> Checkbox. If selected, hidden files 
+			and folders will processed.
 		</li>
 		<li>
 			<b>Include full path in output</b> Checkbox. If selected (the default),
 			the output payload will have the folder path prepended to the filename.
 		</li>
 		<li>
-			<b>Single</b> Checkbox. If selected, only one msg will be sent; the
-			msg.payload will contain an array of filenames.<br />
+			<b>Output single message (array)</b> Checkbox. If selected, only one msg will be 
+			sent; the msg.payload will contain an array of filenames.<br />
 			Otherwise, the default output is a single msg for each file found with
 			the msg.payload a string containing the filename.
+		</li>
+		<li>
+			<b>Max. search depth</b> Integer. Default 0 only searches the start folder.
+			Limits the depth of sub-folders that will be searched.
+		</li>
+		<li>
+			<b>Return file details</b> Checkbox. If selected, details of the files will be
+			returned as part of msg.payload
 		</li>
 	</ul>
 	<p>
 		To override the configured options, pass in a msg with msg.payload like:
 		<code>{"start":"/my/folder","pattern":"*.json"}</code>
-		Any missing options will be picked up from the configured node. Only those 2
-		overrides are currently available.
+		Any missing options will be picked up from the configured node.
 	</p>
 </body>
 </html>

--- a/fs/fs-file-lister.html
+++ b/fs/fs-file-lister.html
@@ -27,8 +27,10 @@
     defaults: { // defines the editable properties of the node
       name:    {value:''},    //  along with default values.
       start:   {value:'/', required:true},   // Start folder
-      pattern: {value:'*'},   // Extension (optional)
-      hidden:  {value:true}, // include hidden files (@since v1.0.2)
+      pattern: {value:'*.*'},   // Extension (optional)
+      filter:  {value:'*'},    // Extension (optional)
+      hidden:  {value:true}, // include hidden files (@since v1.1.2)
+      lstype:  {value:false}, // Output folder names only 
       path:    {value:true},  // Output full path?
       single:  {value:false}, // Output a single array instead of multiple messages
       depth:   {value:0, validate:RED.validators.number()},    // Max recursion depth
@@ -45,12 +47,14 @@
         return this.name ? 'node_label_italic' : '';
     },
     oneditprepare: function () {
+        this.filter = this.filter || "oops"
         if ( this.hidden === undefined ) this.hidden = true
         //#region Set the checkbox states
         $('#node-input-hidden').prop('checked', this.hidden)
         $('#node-input-path').prop('checked', this.path)
         $('#node-input-single').prop('checked', this.single)
         $('#node-input-stat').prop('checked', this.stat)
+        $('#node-input-lstype').prop('unchecked', this.lstype)
         //#endregion checkbox states
     },
   })
@@ -66,13 +70,25 @@
 
   <div class="form-row">
     <label for="node-input-pattern"><i class="fa fa-file-code-o"></i> File Pattern</label>
-    <input type="text" id="node-input-pattern" placeholder="*">
+    <input type="text" id="node-input-pattern" placeholder="*.*">
+  </div>
+
+
+  <div class="form-row">
+    <label for="node-input-filter"><i class="fa fa-file-code-o"></i> Folder Pattern</label>
+    <input type="text" id="node-input-filter" placeholder="*">
   </div>
 
   <div class="form-row">
     <label>&nbsp;</label>
     <input type="checkbox" id="node-input-hidden" style="display: inline-block; width: auto; vertical-align: top;">
     <label for="node-input-hidden" style="width: 70%;">Include hidden files in output?</label>
+  </div>
+
+  <div class="form-row">
+    <label>&nbsp;</label>
+    <input type="checkbox" id="node-input-lstype" style="display: inline-block; width: auto; vertical-align: top;">
+    <label for="node-input-lstype" style="width: 70%;">Search folder names only?</label>
   </div>
 
   <div class="form-row">
@@ -119,8 +135,8 @@
     </ul>
     <h3>What does this node do?</h3>
     <p>
-      This node searches a folder (and optionally sub-folders) for files. optionally
-      may filter on a specific file pattern.
+      This node searches a folder (and optionally sub-folders) for files. Optionally
+      may filter on a specific file pattern or return only the folder name.
     </p>
     <p>
       The folder and files come from the computer and operating system that is
@@ -128,9 +144,8 @@
     </p>
     <h3>Outputs</h3>
     <p>
-      By default, returns one message for each file found. The filename will be
-      in the msg.payload.
-       unless the <i>Output Single Message</i>
+      By default, returns one message for each file/folder found. The file/folder name 
+      will be in the msg.payload unless the <i>Output Single Message</i>
       option is chosen.
     </p>
     <p>
@@ -162,33 +177,46 @@
         Max length is 1024
       </li>
       <li>
-        <b>Search sub-folders</b> Checkbox. If selected, sub-folders under the
-        start folder will also be searched.
+        <b>Folder Pattern</b> [ffilter] Set of strings that indicate the subfolders to 
+        search or avoid searching. If the 'Start Folder' has three sub folders 'A', 'B' 
+        and 'C' and you want to search in 'A' and 'C' but not 'B' you could use "A/!B/C', 'C'"
+        or "!B" (not 'B'). If folder 'C' also has a subfolder 'D' you want to search, you 
+        would use "'A', 'C', 'D'".
       </li>
       <li>
-        <b>Sub-folder Depth</b> Integer. Default 0 only searches the start folder.
-        Limits the depth of sub-folders that will be searched.
-      </li>
-      <li>
-        <b>Show Hidden files</b> checkbox. If selected (default) the msg.payload will
+        <b>Include hidden files in output?</b> checkbox. If selected (default) the msg.payload will
         include any hidden file-/folder-names. Deselect to include them. Note that Windows
         hidden files/folders are not effected unless they start with a dot.
+      </li>
+      <li>
+        <b>Search folder names only?</b> checkbox. If selected the msg.payload will
+        include only folder-names. Note that Windows hidden files/folders are not
+        effected unless they start with a dot.
       </li>
       <li>
         <b>Include full path in output</b> Checkbox. If selected (the default),
         the output payload will have the folder path prepended to the filename.
       </li>
       <li>
-        <b>Single</b> Checkbox. If selected, only one msg will be sent; the
-        msg.payload will contain an array of filenames.<br />
-        Otherwise, the default output is a single msg for each file found with
+        <b>Output single message (array)?</b> Checkbox. If selected, only one msg will be 
+        sent; the msg.payload will contain an array of file/folder names.<br />
+        Otherwise, the default output is a single msg for each file/folder found with
         the msg.payload a string containing the filename.
+      </li>
+      <li>
+        <b>Max. search Depth</b> Integer. Default 0 only searches the start folder.
+        Limits the depth of sub-folders that will be searched.
+      </li>
+     <li>
+        <b>Return file details?</b>  Checkbox. If selected, msg.payload will contain an 
+        array of objects, each containing the name of the file/folder and status Information
+        about it.
       </li>
     </ul>
     <p>
       To override the configured options, pass in a msg with msg.payload like:
-      <code>{"start":"/my/folder","pattern":"*.json"}</code>
-      Any missing options will be picked up from the configured node. Only those 2
+      <code>{"start":"/my/folder","pattern":"*.json","filter":"!context"}</code>
+      Any missing options will be picked up from the configured node. Only those 3
       overrides are currently available.
     </p>
 </script>

--- a/fs/fs-file-lister.html
+++ b/fs/fs-file-lister.html
@@ -48,9 +48,7 @@
     },
     oneditprepare: function () {
         this.filter = this.filter || "oops"
-//        if ( this.lstype === undefined ) this.lstype = "Files"
-        if ( this.lstype === undefined ) this.lstype = "files"
-        $('#node-input-lstype').prop('Files', this.lstype)
+        $('#node-input-lstype').val(this.lstype || 'Files')
         if ( this.hidden === undefined ) this.hidden = true
         //#region Set the checkbox states
         $('#node-input-hidden').prop('checked', this.hidden)

--- a/fs/fs-file-lister.html
+++ b/fs/fs-file-lister.html
@@ -167,49 +167,48 @@
         absolute paths. e.g. /home/pi<br />
         Windows path names are also accepted. On Windows, you can use either form.
         There is no need to escape backslashes.
-        Max path length is 1024 (Overrides with path to starting folder)
+        Max path length is 1024 (override: path to starting folder)
       <li>
         <b>File Pattern</b> [pattern] String that will be matched against the filenames.
-        Standard "glob" file patterns are allowed. Defaults to '*' which will return all files.
-        Max length is 1024 (Overrides with file pattern)
+        Standard "glob" file patterns are allowed. Defaults to '*.*' which will return all files.
+        Max length is 1024 (override: file pattern)
       </li>
       <li>
-        <b>Folders Pattern</b> [folders] Set of strings that indicate the subfolders to 
+        <b>Folders Pattern</b> [folders] Defaults to '*' </br>Set of strings that indicate the subfolders to 
         search or avoid searching. If the 'Start Folder' has three sub folders 'A', 'B' 
         and 'C' and you want to search in 'A' and 'C' but not 'B' you could use "A/!B/C', 'C'"
         or "!B" (not 'B'). If folder 'C' also has a subfolder 'D' you want to search, you 
-        would use "'A', 'C', 'D'". (Overrides with folder pattern)
+        would use "'A', 'C', 'D'". (override: folder pattern)
       </li>
       <li>
         <b>Files/Folders</b> [lstype] This dropdown allows you to list Files (default), Folders 
-        or both in the output. (Overrides with 'files', 'folders' or 'both')
+        or both in the output. (override: 'files', 'folders' or 'both')
       </li>
       <li>
         <b>Include hidden files in output?</b> [hidden] checkbox. If selected (default) the 
         msg.payload will include any hidden file-/folder-names. Deselect to include them. 
         Note that Windows hidden files/folders are not effected unless they start with a dot. 
-        (Overrides with boolean true/false)
+        (override: boolean true/false)
       </li>
       <li>
         <b>Include full path in output</b> [path] checkbox. If selected (the default),
-        the output payload will have the folder path prepended to the filename. (Overrides 
-        with boolean true/false)
+        the output payload will have the folder path prepended to the filename. (override: 
+        boolean true/false)
       </li>
       <li>
         <b>Output single message (array)?</b> [single] checkbox. If selected, only one msg will be 
         sent; the msg.payload will contain an array of file/folder names.<br />
         Otherwise, the default output is a single msg for each file/folder found with
-        the msg.payload a string containing the filename. (Overrides with boolean true/false)
+        the msg.payload a string containing the filename. (override: boolean true/false)
       </li>
       <li>
         <b>Max. search Depth</b> [depth] Integer. Default 0 only searches the start folder.
-        Limits the depth of sub-folders that will be searched (Maximum 10). (Overrides with 
-        an integer <= 10)
+        Limits the depth of sub-folders that will be searched (Maximum 10). (override: integer <= 10)
       </li>
      <li>
         <b>Return file details?</b> [stat] Checkbox. If selected, msg.payload will contain an 
         array of objects, each containing the name of the file/folder and status Information
-        about it. (Overrides with boolean true/false)
+        about it. (override: boolean true/false)
       </li>
     </ul>
     <p>

--- a/fs/fs-file-lister.html
+++ b/fs/fs-file-lister.html
@@ -48,6 +48,7 @@
     },
     oneditprepare: function () {
         this.filter = this.filter || "oops"
+        if ( this.lstype === undefined ) this.lstype = "Files"
         if ( this.hidden === undefined ) this.hidden = true
         //#region Set the checkbox states
         $('#node-input-hidden').prop('checked', this.hidden)

--- a/fs/fs-file-lister.html
+++ b/fs/fs-file-lister.html
@@ -28,9 +28,9 @@
       name:    {value:''},    //  along with default values.
       start:   {value:'/', required:true},   // Start folder
       pattern: {value:'*.*'},   // Extension (optional)
-      filter:  {value:'*'},    // Extension (optional)
+      folders: {value:'*'},    // Extension (optional)
       hidden:  {value:true}, // include hidden files (@since v1.1.2)
-      lstype:  {value:false}, // Output folder names only 
+      lstype:  {value:'files'}, // Output folder names only 
       path:    {value:true},  // Output full path?
       single:  {value:false}, // Output a single array instead of multiple messages
       depth:   {value:0, validate:RED.validators.number()},    // Max recursion depth
@@ -54,9 +54,10 @@
         $('#node-input-path').prop('checked', this.path)
         $('#node-input-single').prop('checked', this.single)
         $('#node-input-stat').prop('checked', this.stat)
-        $('#node-input-lstype').prop('unchecked', this.lstype)
         //#endregion checkbox states
     },
+    
+    labellstype: {value: 'files'}
   })
 </script>
 
@@ -73,22 +74,24 @@
     <input type="text" id="node-input-pattern" placeholder="*.*">
   </div>
 
+  <div class="form-row">
+    <label for="node-input-folders"><i class="fa fa-folder-o"></i> Folder Pattern</label>
+    <input type="text" id="node-input-folders" placeholder="*">
+  </div>
+
 
   <div class="form-row">
-    <label for="node-input-filter"><i class="fa fa-file-code-o"></i> Folder Pattern</label>
-    <input type="text" id="node-input-filter" placeholder="*">
-  </div>
+    <label for="node-input-lstype" style="width:110px;"><i class="icon-tag"></i> Files/Folders</label>
+        <select id="node-input-lstype" placeholder="lstype">
+          <option value="files">Files</option>
+          <option value="directories">Folders</option>
+        </select>
+    </div>
 
   <div class="form-row">
     <label>&nbsp;</label>
     <input type="checkbox" id="node-input-hidden" style="display: inline-block; width: auto; vertical-align: top;">
     <label for="node-input-hidden" style="width: 70%;">Include hidden files in output?</label>
-  </div>
-
-  <div class="form-row">
-    <label>&nbsp;</label>
-    <input type="checkbox" id="node-input-lstype" style="display: inline-block; width: auto; vertical-align: top;">
-    <label for="node-input-lstype" style="width: 70%;">Search folder names only?</label>
   </div>
 
   <div class="form-row">
@@ -177,7 +180,7 @@
         Max length is 1024
       </li>
       <li>
-        <b>Folder Pattern</b> [ffilter] Set of strings that indicate the subfolders to 
+        <b>Folders Pattern</b> [folders] Set of strings that indicate the subfolders to 
         search or avoid searching. If the 'Start Folder' has three sub folders 'A', 'B' 
         and 'C' and you want to search in 'A' and 'C' but not 'B' you could use "A/!B/C', 'C'"
         or "!B" (not 'B'). If folder 'C' also has a subfolder 'D' you want to search, you 
@@ -215,7 +218,7 @@
     </ul>
     <p>
       To override the configured options, pass in a msg with msg.payload like:
-      <code>{"start":"/my/folder","pattern":"*.json","filter":"!context"}</code>
+      <code>{"start":"/my/folder","pattern":"*.json","folders":"!context"}</code>
       Any missing options will be picked up from the configured node. Only those 3
       overrides are currently available.
     </p>

--- a/fs/fs-file-lister.html
+++ b/fs/fs-file-lister.html
@@ -85,6 +85,7 @@
         <select id="node-input-lstype" placeholder="lstype">
           <option value="files">Files</option>
           <option value="directories">Folders</option>
+          <option value="both">Both</option>
         </select>
     </div>
 
@@ -139,7 +140,7 @@
     <h3>What does this node do?</h3>
     <p>
       This node searches a folder (and optionally sub-folders) for files. Optionally
-      may filter on a specific file pattern or return only the folder name.
+      may filter on a specific file or folder pattern or return only the folder name.
     </p>
     <p>
       The folder and files come from the computer and operating system that is
@@ -186,6 +187,14 @@
         or "!B" (not 'B'). If folder 'C' also has a subfolder 'D' you want to search, you 
         would use "'A', 'C', 'D'".
       </li>
+      <li>
+        <b>Files/Folders</b> [lstype] This dropdown allows you to list Files (default), Folders 
+        or both in the output. This can be overridden in the incoming msg.payload.lstype using 'files'
+        'folders' or 'both'
+      </li>
+      
+      Files/Folders 
+      
       <li>
         <b>Include hidden files in output?</b> checkbox. If selected (default) the msg.payload will
         include any hidden file-/folder-names. Deselect to include them. Note that Windows

--- a/fs/fs-file-lister.html
+++ b/fs/fs-file-lister.html
@@ -131,12 +131,6 @@
     <h2>
       Filing System Utilities: File Lister
     </h2>
-    <h3>To Do</h3>
-    <ul>
-      <li>
-        Allow other overrides to be passed in.
-      </li>
-    </ul>
     <h3>What does this node do?</h3>
     <p>
       This node searches a folder (and optionally sub-folders) for files. Optionally
@@ -173,62 +167,54 @@
         absolute paths. e.g. /home/pi<br />
         Windows path names are also accepted. On Windows, you can use either form.
         There is no need to escape backslashes.
-        Max path length is 1024
-      </li>
+        Max path length is 1024 (Overrides with path to starting folder)
       <li>
         <b>File Pattern</b> [pattern] String that will be matched against the filenames.
         Standard "glob" file patterns are allowed. Defaults to '*' which will return all files.
-        Max length is 1024
+        Max length is 1024 (Overrides with file pattern)
       </li>
       <li>
         <b>Folders Pattern</b> [folders] Set of strings that indicate the subfolders to 
         search or avoid searching. If the 'Start Folder' has three sub folders 'A', 'B' 
         and 'C' and you want to search in 'A' and 'C' but not 'B' you could use "A/!B/C', 'C'"
         or "!B" (not 'B'). If folder 'C' also has a subfolder 'D' you want to search, you 
-        would use "'A', 'C', 'D'".
+        would use "'A', 'C', 'D'". (Overrides with folder pattern)
       </li>
       <li>
         <b>Files/Folders</b> [lstype] This dropdown allows you to list Files (default), Folders 
-        or both in the output. This can be overridden in the incoming msg.payload.lstype using 'files'
-        'folders' or 'both'
-      </li>
-      
-      Files/Folders 
-      
-      <li>
-        <b>Include hidden files in output?</b> checkbox. If selected (default) the msg.payload will
-        include any hidden file-/folder-names. Deselect to include them. Note that Windows
-        hidden files/folders are not effected unless they start with a dot.
+        or both in the output. (Overrides with 'files', 'folders' or 'both')
       </li>
       <li>
-        <b>Search folder names only?</b> checkbox. If selected the msg.payload will
-        include only folder-names. Note that Windows hidden files/folders are not
-        effected unless they start with a dot.
+        <b>Include hidden files in output?</b> [hidden] checkbox. If selected (default) the 
+        msg.payload will include any hidden file-/folder-names. Deselect to include them. 
+        Note that Windows hidden files/folders are not effected unless they start with a dot. 
+        (Overrides with boolean true/false)
       </li>
       <li>
-        <b>Include full path in output</b> Checkbox. If selected (the default),
-        the output payload will have the folder path prepended to the filename.
+        <b>Include full path in output</b> [path] checkbox. If selected (the default),
+        the output payload will have the folder path prepended to the filename. (Overrides 
+        with boolean true/false)
       </li>
       <li>
-        <b>Output single message (array)?</b> Checkbox. If selected, only one msg will be 
+        <b>Output single message (array)?</b> [single] checkbox. If selected, only one msg will be 
         sent; the msg.payload will contain an array of file/folder names.<br />
         Otherwise, the default output is a single msg for each file/folder found with
-        the msg.payload a string containing the filename.
+        the msg.payload a string containing the filename. (Overrides with boolean true/false)
       </li>
       <li>
-        <b>Max. search Depth</b> Integer. Default 0 only searches the start folder.
-        Limits the depth of sub-folders that will be searched.
+        <b>Max. search Depth</b> [depth] Integer. Default 0 only searches the start folder.
+        Limits the depth of sub-folders that will be searched (Maximum 10). (Overrides with 
+        an integer <= 10)
       </li>
      <li>
-        <b>Return file details?</b>  Checkbox. If selected, msg.payload will contain an 
+        <b>Return file details?</b> [stat] Checkbox. If selected, msg.payload will contain an 
         array of objects, each containing the name of the file/folder and status Information
-        about it.
+        about it. (Overrides with boolean true/false)
       </li>
     </ul>
     <p>
       To override the configured options, pass in a msg with msg.payload like:
       <code>{"start":"/my/folder","pattern":"*.json","folders":"!context"}</code>
-      Any missing options will be picked up from the configured node. Only those 3
-      overrides are currently available.
+      Any missing options will be picked up from the configured node. 
     </p>
 </script>

--- a/fs/fs-file-lister.html
+++ b/fs/fs-file-lister.html
@@ -48,6 +48,7 @@
     },
     oneditprepare: function () {
         this.filter = this.filter || "oops"
+        if ( this.lstype === undefined ) this.lstype = "Files"
         $('#node-input-lstype').val(this.lstype || 'Files')
         if ( this.hidden === undefined ) this.hidden = true
         //#region Set the checkbox states

--- a/fs/fs-file-lister.html
+++ b/fs/fs-file-lister.html
@@ -47,9 +47,8 @@
         return this.name ? 'node_label_italic' : '';
     },
     oneditprepare: function () {
-        this.filter = this.filter || "oops"
-        if ( this.lstype === undefined ) this.lstype = "Files"
-        $('#node-input-lstype').val(this.lstype || 'Files')
+        // handle new option 'list type'
+        if ( this.lstype === undefined ) this.lstype = "files"
         if ( this.hidden === undefined ) this.hidden = true
         //#region Set the checkbox states
         $('#node-input-hidden').prop('checked', this.hidden)
@@ -58,8 +57,6 @@
         $('#node-input-stat').prop('checked', this.stat)
         //#endregion checkbox states
     },
-    
-    labellstype: {value: 'files'}
   })
 </script>
 

--- a/fs/fs-file-lister.html
+++ b/fs/fs-file-lister.html
@@ -48,7 +48,9 @@
     },
     oneditprepare: function () {
         this.filter = this.filter || "oops"
-        if ( this.lstype === undefined ) this.lstype = "Files"
+//        if ( this.lstype === undefined ) this.lstype = "Files"
+        if ( this.lstype === undefined ) this.lstype = "files"
+        $('#node-input-lstype').prop('Files', this.lstype)
         if ( this.hidden === undefined ) this.hidden = true
         //#region Set the checkbox states
         $('#node-input-hidden').prop('checked', this.hidden)

--- a/fs/fs-file-lister.js
+++ b/fs/fs-file-lister.js
@@ -169,11 +169,11 @@ module.exports = function(RED) {
                 }
             }
 
-//			change shashes (/) to commas (,) then get rid of extra spaces
+	    // change shashes (/) to commas (,) then get rid of extra spaces
             node.folders = node.folders.replace(/\//g,",")
             node.folders = node.folders.replace(/ /g,"")
             
-//			split the file and directory options into arrays arguments for 'readdirp'
+	    // split the file and directory options into arrays arguments for 'readdirp'
             options.fileFilter = node.pattern.split(',')
             options.directoryFilter = node.folders.split(',')
 

--- a/fs/fs-file-lister.js
+++ b/fs/fs-file-lister.js
@@ -66,24 +66,46 @@ module.exports = function(RED) {
             // If this is pre-1.0, 'done' will be undefined, so fallback to dummy function
             done = done || function() { if (arguments.length>0) node.error.apply(node,arguments) }
 
-            // override config if passed suitable payload
+		// ---------------------------------------------------------
+ 		// this section handles the overriding 'config' if option coming in msg.payload
+ 		// ---------------------------------------------------------
+            // override 'start if passed suitable payload
             if ( (typeof msg.payload === 'object') && ('start' in msg.payload) ) {
                 if ( validFolderName(msg.payload.start) ) {
                     node.start = msg.payload.start
                }
             }
-            // file pattern
+            // override file 'pattern' if passed suitable payload
             if ( (typeof msg.payload === 'object') && ('pattern' in msg.payload) ) {
                 if ( (typeof msg.payload.pattern === 'string') && (msg.payload.pattern.length < 1024) ) {
                     node.pattern = msg.payload.pattern
                 }
             }
-            
+            // override 'folders' pattern if passed suitable payload
+            if ( (typeof msg.payload === 'object') && ('folders' in msg.payload) ) {
+                if ( (typeof msg.payload.folders === 'string') && (msg.payload.folders.length < 1024) ) {
+                    node.folders = msg.payload.folders
+                }
+            }
+            // override 'lstype' if passed suitable payload
             if ( (typeof msg.payload === 'object') && ('lstype' in msg.payload) ) {
                 if ( (typeof msg.payload.lstype === 'string') && (msg.payload.lstype.length < 50) ) {
                     node.lstype = msg.payload.lstype.toLowerCase()
                 }
             }
+            // override 'hidden' if passed suitable payload
+            if ( (typeof msg.payload === 'object') && ('hidden' in msg.payload) ) {
+                if ( (typeof msg.payload.hidden === 'boolean')  ) {
+                    node.hidden = msg.payload.hidden
+                }
+            }
+            // override 'hidden' if passed suitable payload
+            if ( (typeof msg.payload === 'object') && ('hidden' in msg.payload) ) {
+                if ( (typeof msg.payload.hidden === 'boolean')  ) {
+                    node.hidden = msg.payload.hidden
+                }
+            }
+            // override 'depth' if passed suitable payload
             if ( (typeof msg.payload === 'object') && ('depth' in msg.payload) ) {
                 if ( (typeof msg.payload.depth === 'number') && (msg.payload.depth < 10) ) {
                     node.depth = msg.payload.depth
@@ -134,11 +156,11 @@ module.exports = function(RED) {
                 }
             }
 
-//			change shashes (/) to commas (,) then get rid of extra spaces
+	    // change shashes (/) to commas (,) then get rid of extra spaces
             node.folders = node.folders.replace(/\//g,",")
             node.folders = node.folders.replace(/ /g,"")
             
-//			split the file and directory options into arrays arguments for 'readdirp'
+	    // split the file and directory options into arrays arguments for 'readdirp'
             options.fileFilter = node.pattern.split(',')
             options.directoryFilter = node.folders.split(',')
 

--- a/fs/fs-file-lister.js
+++ b/fs/fs-file-lister.js
@@ -145,6 +145,7 @@ module.exports = function(RED) {
 
             var options = {}
             
+            if (node.lstype == 'folders') {node.lstype = 'directories'}
             if (node.lstype == 'both') {node.lstype = 'files_directories'}
            	options.type = node.lstype
             	

--- a/fs/fs-file-lister.js
+++ b/fs/fs-file-lister.js
@@ -39,16 +39,16 @@ module.exports = function(RED) {
         node.name     = config.name
         node.start    = config.start
         node.pattern  = config.pattern
-        node.folders  = config.folders 
-        node.lstype   = config.lstype 
-        node.hidden   = config.hidden !== undefined ? config.hidden : true  /** @since v1.0.2 */
+        node.folders  = config.folders !== undefined ? config.folders : "*"
+        node.lstype   = config.lstype  !== undefined ? config.lstype : "files"
+        node.hidden   = config.hidden  !== undefined ? config.hidden : true  /** @since v1.0.2 */
         node.path     = config.path
         node.single   = config.single
-        node.depth    = config.depth
+        node.depth    = config.depth   
         node.stat     = config.stat
                 
-		if (node.pattern == "") node.pattern = "*.*"
-		if (node.folders == "") node.folders = "*"
+		if ( (node.pattern == "") || (node.pattern == "*") ) node.pattern = "*.*"
+		if  (node.folders == "") node.folders = "*"
 
 
         // Make sure the parameters are strings
@@ -78,8 +78,9 @@ module.exports = function(RED) {
                     node.pattern = msg.payload.pattern
                 }
             }
+            
             if ( (typeof msg.payload === 'object') && ('lstype' in msg.payload) ) {
-                if ( (typeof msg.payload.lstype === 'string') && (msg.payload.lstype.length < 20) ) {
+                if ( (typeof msg.payload.lstype === 'string') && (msg.payload.lstype.length < 50) ) {
                     node.lstype = msg.payload.lstype.toLowerCase()
                 }
             }
@@ -110,6 +111,7 @@ module.exports = function(RED) {
 
             var options = {}
             
+            if (node.lstype == 'both') {node.lstype = 'files_directories'}
            	options.type = node.lstype
             	
             if ( node.depth > -1 ) {
@@ -119,12 +121,16 @@ module.exports = function(RED) {
             /** Show hidden files/folders? Unless explicitly asked for, readdirp will ignore them
              * NB: doesn't help with Windows hidden files/folders
              **/
-             node.pattern = node.pattern.replace(/ /g,"")
+            node.pattern = node.pattern.replace(/ /g,"")
              if ( node.hidden === true ) {
                 // No need for this if supplied patter starts with a dot
                 if (node.pattern.charAt(0) !== '.') {
                     var np = node.pattern.replace(/,/g,",.")
                     node.pattern = node.pattern +",."+np
+                }
+                if (node.folders.charAt(0) !== '.') {
+                    var nf = node.folders.replace(/,/g,",.")
+                    node.folders = node.folders +",."+nf
                 }
             }
 

--- a/fs/fs-file-lister.js
+++ b/fs/fs-file-lister.js
@@ -123,6 +123,9 @@ module.exports = function(RED) {
                     node.stat = msg.payload.stat
                 }
             }
+            
+            if (node.lstype == 'folders') {node.lstype = 'directories'}
+            if (node.lstype == 'both') {node.lstype = 'files_directories'}
 
             var clonedMsg = RED.util.cloneMessage(msg)
             // Remove original _msgid
@@ -144,10 +147,8 @@ module.exports = function(RED) {
             var totalFiles = 0
 
             var options = {}
-            
-            if (node.lstype == 'folders') {node.lstype = 'directories'}
-            if (node.lstype == 'both') {node.lstype = 'files_directories'}
-           	options.type = node.lstype
+	    
+            options.type = node.lstype
             	
             if ( node.depth > -1 ) {
                 options.depth = Number(node.depth)

--- a/fs/fs-file-lister.js
+++ b/fs/fs-file-lister.js
@@ -99,16 +99,28 @@ module.exports = function(RED) {
                     node.hidden = msg.payload.hidden
                 }
             }
-            // override 'hidden' if passed suitable payload
-            if ( (typeof msg.payload === 'object') && ('hidden' in msg.payload) ) {
-                if ( (typeof msg.payload.hidden === 'boolean')  ) {
-                    node.hidden = msg.payload.hidden
+            // override 'path' if passed suitable payload
+            if ( (typeof msg.payload === 'object') && ('path' in msg.payload) ) {
+                if ( (typeof msg.payload.path === 'boolean')  ) {
+                    node.path = msg.payload.path
+                }
+            }
+            // override 'single' if passed suitable payload
+            if ( (typeof msg.payload === 'object') && ('single' in msg.payload) ) {
+                if ( (typeof msg.payload.single === 'boolean')  ) {
+                    node.single = msg.payload.single
                 }
             }
             // override 'depth' if passed suitable payload
             if ( (typeof msg.payload === 'object') && ('depth' in msg.payload) ) {
-                if ( (typeof msg.payload.depth === 'number') && (msg.payload.depth < 10) ) {
+                if ( (typeof msg.payload.depth === 'number') && (msg.payload.depth < 11) ) {
                     node.depth = msg.payload.depth
+                }
+            }
+            // override 'stat' if passed suitable payload
+            if ( (typeof msg.payload === 'object') && ('stat' in msg.payload) ) {
+                if ( (typeof msg.payload.stat === 'boolean')  ) {
+                    node.stat = msg.payload.stat
                 }
             }
 
@@ -156,11 +168,11 @@ module.exports = function(RED) {
                 }
             }
 
-	    // change shashes (/) to commas (,) then get rid of extra spaces
+//			change shashes (/) to commas (,) then get rid of extra spaces
             node.folders = node.folders.replace(/\//g,",")
             node.folders = node.folders.replace(/ /g,"")
             
-	    // split the file and directory options into arrays arguments for 'readdirp'
+//			split the file and directory options into arrays arguments for 'readdirp'
             options.fileFilter = node.pattern.split(',')
             options.directoryFilter = node.folders.split(',')
 


### PR DESCRIPTION
We welcome new pull requests to this repository but please follow the [contribution guidelines](https://github.com/TotallyInformation/node-red-contrib-fs/blob/master/.github/CONTRIBUTING.md).

Ensure that you are happy with the license for this repository and that all of your code meets the requirements for the license.

Please include the following information:

### A reference to any related issues in this repository


### A description of the changes proposed in the pull request and why
Updated fs-lister to allow folder patterns, choose to look at files, folders or both and updated the documentation

### Environment used for development and testing

Software       | Version
-------------- | -------
Node.JS        | v10.17.0 (1) and v12.13.0 (2)
npm            | 6.11.3 (1) and 6.13.4 (2)
Node-RED       | 1.0.3
fs node        | lister
OS             | Rpi (1) and macOS (2)
Browser        | Safari

